### PR TITLE
Arreglo links a "Tutorial: Crear un módulo de Go"

### DIFF
--- a/2.Tutorial-Primeros_Pasos/README.md
+++ b/2.Tutorial-Primeros_Pasos/README.md
@@ -135,4 +135,4 @@ Cuando corriste `go mod tidy`, se encontró y descargó el módulo `rsc.io/quote
 
 ## Escribiendo más código
 
-Con está rápida introducción, tendrás Go instalado y aprendiste algunas cosas básicas. Para escribir más código con otro tutorial, hecha un vistazo a [Crear un módulo de Go](../tutorial/1.Tutorial-Create_a_Go_module/README.md).
+Con está rápida introducción, tendrás Go instalado y aprendiste algunas cosas básicas. Para escribir más código con otro tutorial, hecha un vistazo a [Crear un módulo de Go](../tutorial/1.Tutorial-Crear_un_modulo_de_go/README.md).


### PR DESCRIPTION
Se tradujo el directorio y se arreglaron los links a este